### PR TITLE
Add UI tests for KEYCLOAK-11684

### DIFF
--- a/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/KcPassword.java
+++ b/testsuite/integration-arquillian/tests/base/src/main/java/org/keycloak/testsuite/console/page/fragment/KcPassword.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.fragment;
+
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.openqa.selenium.ElementNotInteractableException;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class KcPassword {
+    @Root
+    private WebElement inputField;
+
+    @FindBy(xpath = "../span[contains(@class,'input-group-addon') and ./span[contains(@class,'fa-eye')]]")
+    private WebElement eyeButton;
+
+    public void setValue(final String value) {
+        setTextInputValue(inputField, value);
+    }
+
+    public boolean isMasked() {
+        return inputField.getAttribute("class").contains("password-conceal");
+    }
+
+    public boolean isEyeButtonDisabled() {
+        return eyeButton.getAttribute("class").contains("disabled");
+    }
+
+    public void clickEyeButton() {
+        if (isEyeButtonDisabled()) {
+            throw new ElementNotInteractableException("The eye button is disabled and cannot be clicked");
+        }
+        eyeButton.click();
+    }
+
+    public WebElement getElement() {
+        return inputField;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/federation/LdapUserProviderForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/federation/LdapUserProviderForm.java
@@ -54,9 +54,6 @@ public class LdapUserProviderForm extends Form {
     @FindBy(id = "ldapBindCred")
     private WebElement ldapBindCredentialInput;
 
-    @FindBy(xpath = ".//span[../input[@id = 'ldapBindCred']]")
-    private WebElement ldapBindCredentialMaskButton;
-
     @FindBy(id = "customUserSearchFilter")
     private WebElement customUserSearchFilterInput;
 
@@ -184,14 +181,6 @@ public class LdapUserProviderForm extends Form {
 
     public void setLdapBindDnInput(String ldapBindDn) {
         UIUtils.setTextInputValue(ldapBindDnInput, ldapBindDn);
-    }
-
-    public boolean isLdapBindCredentialInputPasswordMasked() {
-        return ldapBindCredentialInput.getAttribute("class").matches(".*\\bpassword-conceal\\b.*");
-    }
-
-    public void toggleLdapBindCredentialInputPasswordMasked() {
-        ldapBindCredentialMaskButton.click();
     }
 
     public void setLdapBindCredentialInput(String ldapBindCredential) {

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/CreateIdentityProvider.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/CreateIdentityProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.jboss.arquillian.graphene.page.Page;
+import org.keycloak.testsuite.console.page.AdminConsoleCreate;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class CreateIdentityProvider extends AdminConsoleCreate {
+    public static final String PROVIDER_ID = "provider-id";
+
+    @Page
+    private IdentityProviderForm form;
+
+    public CreateIdentityProvider() {
+        setEntity("identity-provider");
+    }
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/{" + PROVIDER_ID + "}";
+    }
+
+    public void setProviderId(String id) {
+        setUriParameter(PROVIDER_ID, id);
+    }
+
+    public String getProviderId() {
+        return (String) getUriParameter(PROVIDER_ID);
+    }
+
+    public IdentityProviderForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProvider.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProvider.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.jboss.arquillian.graphene.page.Page;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class IdentityProvider extends IdentityProviders {
+    public static final String PROVIDER_ID = "id";
+    public static final String ALIAS = "alias";
+
+    @Page
+    private IdentityProviderForm form;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/provider/{" + PROVIDER_ID + "}/{" + ALIAS + "}";
+    }
+
+    public void setIds(String providerId, String alias) {
+        setUriParameter(PROVIDER_ID, providerId);
+        setUriParameter(ALIAS, alias);
+    }
+
+    public String getProviderId() {
+        return (String) getUriParameter(PROVIDER_ID);
+    }
+
+    public String getAlias() {
+        return (String) getUriParameter(ALIAS);
+    }
+
+    public IdentityProviderForm form() {
+        return form;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviderForm.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviderForm.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.keycloak.testsuite.console.page.fragment.KcPassword;
+import org.keycloak.testsuite.page.Form;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+
+import static org.keycloak.testsuite.util.UIUtils.setTextInputValue;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class IdentityProviderForm extends Form {
+    @FindBy(id = "clientId")
+    private WebElement clientIdInput;
+
+    @FindBy(id = "clientSecret")
+    private KcPassword clientSecretInput;
+
+    public void setClientId(final String value) {
+        setTextInputValue(clientIdInput, value);
+    }
+
+    public void setClientSecret(final String value) {
+        clientSecretInput.setValue(value);
+    }
+
+    public KcPassword clientSecret() {
+        return clientSecretInput;
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviders.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/main/java/org/keycloak/testsuite/console/page/idp/IdentityProviders.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2019 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.keycloak.testsuite.console.page.idp;
+
+import org.jboss.arquillian.graphene.fragment.Root;
+import org.keycloak.testsuite.console.page.AdminConsoleRealm;
+import org.keycloak.testsuite.console.page.fragment.DataTable;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.Select;
+
+import static org.keycloak.testsuite.util.UIUtils.isElementVisible;
+import static org.keycloak.testsuite.util.UIUtils.performOperationWithPageReload;
+
+/**
+ * @author Vaclav Muzikar <vmuzikar@redhat.com>
+ */
+public class IdentityProviders extends AdminConsoleRealm {
+    @FindBy(xpath = "//div[contains(@class,'blank-slate')]//select")
+    private Select addProviderBlankSlateSelect;
+
+    @FindBy(tagName = "table")
+    private IdentityProvidersTable table;
+
+    @Override
+    public String getUriFragment() {
+        return super.getUriFragment() + "/identity-provider-settings";
+    }
+
+    public IdentityProvidersTable table() {
+        return table;
+    }
+
+    public void addProvider(final String providerId) {
+        Select idpSelect = table.isVisible() ? table.addProviderTableSelect : addProviderBlankSlateSelect;
+        performOperationWithPageReload(() -> idpSelect.selectByValue(providerId));
+    }
+
+    public class IdentityProvidersTable extends DataTable {
+        @Root
+        private WebElement tableRoot;
+
+        @FindBy(tagName = "select")
+        private Select addProviderTableSelect;
+
+        public boolean isVisible() {
+            return isElementVisible(tableRoot);
+        }
+
+        public void clickProvider(final String alias) {
+            clickRowByLinkText(alias);
+        }
+    }
+}

--- a/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/federation/LdapUserFederationTest.java
+++ b/testsuite/integration-arquillian/tests/other/console/src/test/java/org/keycloak/testsuite/console/federation/LdapUserFederationTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
@@ -95,13 +94,6 @@ public class LdapUserFederationTest extends AbstractConsoleTest {
         createLdapUserProvider.form().setLdapBindDnInput("uid=admin,ou=system");
         createLdapUserProvider.form().setLdapUserDnInput("ou=People,dc=keycloak,dc=org");
         createLdapUserProvider.form().setLdapBindCredentialInput("secret");
-
-        assertTrue("Password is masked", createLdapUserProvider.form().isLdapBindCredentialInputPasswordMasked());
-        createLdapUserProvider.form().toggleLdapBindCredentialInputPasswordMasked();
-        assertFalse("Password is not masked", createLdapUserProvider.form().isLdapBindCredentialInputPasswordMasked());
-        createLdapUserProvider.form().toggleLdapBindCredentialInputPasswordMasked();
-        assertTrue("Password is masked", createLdapUserProvider.form().isLdapBindCredentialInputPasswordMasked());
-
         createLdapUserProvider.form().save();
         assertAlertDanger();
         createLdapUserProvider.form().setLdapUserDnInput("");


### PR DESCRIPTION
It seems like a lot but it's really just a few Page Objects. It has to be this way to use the same code patterns as the rest of the Admin Console tests.