### PR TITLE
Temporarily disable cancelling concurrent jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ env:
   DEFAULT_JDK_VERSION: 11
   MAVEN_OPTS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.class=standard -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
-concurrency:
+#concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # group: ${{ github.workflow }}-${{ github.ref }}
+  # cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
As we are working on stabilizing the testsuite I'm at least temporarily disabling cancelling of runs with the same ref as this is causing the nightly scheduled runs to sometimes be cancelled.

I don't think we need this to be honest, as this won't happen for PRs normally. For a PR you'd need to either push new commits, or to re-run the job (which requires the previous run to complete first).